### PR TITLE
Missing required parameter

### DIFF
--- a/PandoraSettings/PandoraSettingsDefault.xml
+++ b/PandoraSettings/PandoraSettingsDefault.xml
@@ -389,6 +389,7 @@
     </algorithm>
 
     <algorithm type = "MuonClusterAssociation">
+        <TargetClusterListName>PrimaryClusters</TargetClusterListName>
         <MuonClusterListName>MuonRemovedYokeClusters</MuonClusterListName>
     </algorithm>
 


### PR DESCRIPTION
After running the simulation (ddsim) attempt to run reconstruction with Marlin and you receive the following error

![erorr2](https://user-images.githubusercontent.com/5635401/33615450-d3efa962-d99f-11e7-839f-72d6d4517990.png)

This is due to using the latest LCGEO version with the CVMFS release of ILCSoft v01-19-05, which uses v03-00-02 of LCContent. This introduced a new required parameter (TargetClusterListName) for reconstruction.

BEGINRELEASENOTES
- Added TargetClusterListName parameter to MuonClusterAssociation in PandoraSettingsDefault.xml as required by LCContent v03-00-02 and ILCSoft v01-19-05.
ENDRELEASENOTES